### PR TITLE
Adds timesheet package to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     # packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    packages=['timesheet'],
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
This fixes the issue [you posted on StackOverflow](https://stackoverflow.com/questions/31460921/import-error-after-publish-to-python-package-index/31466813#31466813). It adds the `timesheet` package to the `setup.py` file.
